### PR TITLE
Make control_point take references to LocPhases, not LocPhases themselves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: rust
-rust: stable
+rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,11 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#![feature(integer_atomics)]
+#![feature(test)]
+
+extern crate test;
+
 pub mod metatracer;
 
-pub use metatracer::MetaTracer;
+pub use metatracer::{Location, MetaTracer};


### PR DESCRIPTION
Make control_point take references to LocPhases, not LocPhases themselves.

We initially inherited the RPython idea that the way to express a control_point is to take in a location in the end user's program and then see if the hot threshold for that point has been exceeded or not. The good thing about this is that it's a simple user API. However, underneath, we use a hashtable: every time you call the control_point, you have to pay the costs of calculating a hash and performing a hash lookup. These are fairly cheap operations, but they're not free, and in the context of a tight interpreter loop they're likely to be noticeable. To add insult to injury, in our multi-threading context, a thread-safe hashmap adds additional costs. For users who want to squeeze out every last bit of performance, this is not great.

Fortunately, there seems to me to be an obvious solution. Instead of taking in a user program's location and internally storing a LocPhase, we ask users to give us a reference to the LocPhase corresponding to the current location. At the very worst: for a bytecode interpreter, a user can simply allocate a Vec with one entry per bytecode; for an AST interpreter a LocPhase per node.

At its simplest, the API looks as follows:

```rust
  let lp = LocPhase::new();
  mt.control_point(&lp);
```

For users who care more about memory usage, it isn't difficult to imagine some simple changes to a language's compiler. For example, if we have a loop like:

```rust
  for x in 0..10 {
     ...
  }
```

it would traditionally end up being transformed into bytecode such as:

```
      SET x, 0
  L0: ...
      ADD x, 1
      CMP x, 10
      JLT L0
```

We know that the interpreter only needs to call control_point at L0 (since nowhere else in that snippet can be the start of a loop). We could, for example, add a new bytecode whose sole job is to call control_point e.g.:

```
      SET x, 0
  L0: START_LOOP
      ...
      ADD x, 1
      CMP x, 10
      JLT L0
```

Since this is fairly easy for a compiler to work this out, it should also be fairly easy to store a LocPhase corresponding to that START_LOOP bytecode.

This API also allows us to free ourselves from the idea that there has to be a single lock for all LocPhases. What this commit first does is to turn LocPhases from an enum into a packed integer with a tag (the top 2 bits) and value (the other 30 bits). We can then uses atomic integers to reduce the read/write costs to as low as is practical. On an amd64 machine, the "common" case (which is that there is a compiled trace available) is exactly equivalent to a normal load (i.e. there are no CAS-esque costs and no possibility of threads starving each other out). [We do have to deal with the possibility that, while we're incrementing hot counts, multiple threads can be operating on the same LocPhase: fortunately a simple spin-lock-esque deals with this nicely. If you crank up the DEFAULT_HOT_THRESHOLD, you can see races happen, and dealt with correctly.]

Let me put some rough performance numbers on this. There are two Cargo benchmarks in this PR. On bencher8 they run thus:

```
  test metatracer::tests::bench_multi_threaded_control_point  ... bench:     148,637 ns/iter (+/- 8,489)
  test metatracer::tests::bench_single_threaded_control_point ... bench:      55,782 ns/iter (+/- 514)
```

I've ported those two benchmarks to the code-before-this-commit (always using a single location "0") and they run thus:

```
  test metatracer::tests::bench_multi_threaded_control_point  ... bench:  68,497,983 ns/iter (+/- 1,715,450)
  test metatracer::tests::bench_single_threaded_control_point ... bench:   4,100,744 ns/iter (+/- 3,549)
```

That means that the multi_threaded benchmark has sped up ~450x and the single_threaded benchmark has sped up ~75x.

Working out what part of that speed-up is the lack of locking and what's down to dictionaries is tricky. As a rough (rough!) experiment, I took the code-before-this-commit and removed the dictionary lookups (i.e. doing the mutex locking, but not the dict lookup) and got. The new multi_threaded then becomes only ~270x faster and the new single_threaded only ~30x faster. That suggests that the speed-up is roughly split 50/50 between removing locking and removing dictionary lookups.

Summary: we allow interpreter authors who care about performance to avoid hashtable costs; and we make performance about as good on a multi-threaded system as I know how to do.
