### PR TITLE
Make way for compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@ name = "yorickrt"
 version = "0.1.0"
 authors = ["Edd Barrett <vext01@gmail.com>", "Laurence Tratt <laurie@tratt.net>"]
 
+[dependencies]
+hwtracer = {git = "https://github.com/softdevteam/hwtracer"}

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-extern crate hwtracer;
-
-use hwtracer::backends::consumer_build_rs_config;
-
-fn main() {
-   consumer_build_rs_config();
-}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+extern crate hwtracer;
+
+use hwtracer::backends::consumer_build_rs_config;
+
+fn main() {
+   consumer_build_rs_config();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 #![feature(test)]
 
 extern crate test;
+extern crate hwtracer;
 
 pub mod metatracer;
 


### PR DESCRIPTION
These changes:
 * Pull in hwtracer and collect traces when appropriate.
 * Scaffold the bits needed to compile in a background thread.
 * Adds more tests.

I suspect there will be a fair amount of dialog on this one.

This depends upon:
https://github.com/softdevteam/hwtracer/pull/72
Tests will fail until that is merged.

[I have some other bits stashed away, but I've opted to use smaller PRs instead of one big one].